### PR TITLE
Lawn mower

### DIFF
--- a/src/assets/Zombie.java
+++ b/src/assets/Zombie.java
@@ -1,6 +1,5 @@
 package assets;
 
-import java.awt.List;
 
 import engine.Board;
 import engine.Game;

--- a/src/assets/Zombie.java
+++ b/src/assets/Zombie.java
@@ -1,6 +1,9 @@
 package assets;
 
+import java.awt.List;
+
 import engine.Board;
+import engine.Game;
 
 /**
  * The Zombie class initializes a set of variables and implements associated setters and getters
@@ -166,7 +169,7 @@ public abstract class Zombie implements Unit{
 	 * 
 	 * @return true if move was not stopped by plant, false otherwise
 	 */
-	public boolean move(int maxRow) {
+	public boolean move(Game game) {
 
 		if (immobilized) {
 			immobilized = false;
@@ -177,7 +180,7 @@ public abstract class Zombie implements Unit{
 			}
 		}
 		
-		return listener.onZombieMove(this, maxRow);
+		return listener.onZombieMove(this, game);
 	}
 
 	/**

--- a/src/assets/Zombie.java
+++ b/src/assets/Zombie.java
@@ -168,7 +168,7 @@ public abstract class Zombie implements Unit{
 	 * 
 	 * @return true if move was not stopped by plant, false otherwise
 	 */
-	public boolean move(Game game) {
+	public boolean move() {
 
 		if (immobilized) {
 			immobilized = false;
@@ -179,7 +179,7 @@ public abstract class Zombie implements Unit{
 			}
 		}
 		
-		return listener.onZombieMove(this, game);
+		return listener.onZombieMove(this);
 	}
 
 	/**

--- a/src/engine/Board.java
+++ b/src/engine/Board.java
@@ -555,7 +555,7 @@ public class Board implements ZombieMoveListener, Serializable {
 			
 			// can move zombie until it reaches end of grid or reaches a plant
 			if (!(currentZombieCol - i < 0)) {
-				if(getNewZomPosition(currentZombieRow, currentZombieCol, modifier, zombie, game.getLevelInfo().getRows()).isOccupied()){
+				if(getNewZomPosition(currentZombieRow, currentZombieCol, modifier, zombie, getRow()).isOccupied()){
 					break;
 				}
 			}
@@ -583,7 +583,7 @@ public class Board implements ZombieMoveListener, Serializable {
 		}
 		else
 		{
-			int[] coord = getNewZomPosition(currentZombieRow, currentZombieCol, modifier, zombie, game.getLevelInfo().getRows()).getCoordinates();
+			int[] coord = getNewZomPosition(currentZombieRow, currentZombieCol, modifier, zombie, getRow()).getCoordinates();
 			zombie.setRow(coord[0]);
 			zombie.setColumn(coord[1]);
 		}

--- a/src/engine/Board.java
+++ b/src/engine/Board.java
@@ -464,7 +464,7 @@ public class Board implements ZombieMoveListener, Serializable {
 	/**
 	 * Returns a list of all the units in the row. Null if no units are in the row
 	 * @param x - the row that is to be checked for units
-	 * @return
+	 * @return - A list of Unit instances that are within the specified row
 	 */
 	public List<Unit> getRowUnits(int x)
 	{
@@ -485,6 +485,7 @@ public class Board implements ZombieMoveListener, Serializable {
 	/**
 	 * Deletes all the units within the specified row
 	 * @param row - the row that all the units will be deleted in
+	 * @return - a list of zombie instances that are to be removed from the board in Game
 	 */
 	public List<Zombie> useLawnMower(int row)
 	{

--- a/src/engine/Board.java
+++ b/src/engine/Board.java
@@ -518,6 +518,7 @@ public class Board implements ZombieMoveListener, Serializable {
 	 */
 	public boolean isMowerAvaliable(int row)
 	{
+		LOG.debug("Checking if lawn mower " + row + " is available and it returns " + mowersAvaliable.contains(row));
 		return mowersAvaliable.contains(row);
 	}
 	
@@ -576,6 +577,7 @@ public class Board implements ZombieMoveListener, Serializable {
 				{
 					g.updateMower(currentZombieRow);
 				}
+				mowersAvaliable.remove((Object) currentZombieRow);
 			}
 			
 			return true;

--- a/src/engine/Board.java
+++ b/src/engine/Board.java
@@ -490,24 +490,22 @@ public class Board implements ZombieMoveListener, Serializable {
 	{
 		List<Unit> unitRemoveBin = getRowUnits(row);
 		List<Zombie> zomRemoveBin = new LinkedList<Zombie>();
-		
-		if(!unitRemoveBin.isEmpty())
+			
+		for(Unit u : unitRemoveBin)
 		{
-			for(Unit u : unitRemoveBin)
+			if(u instanceof Zombie)
 			{
-				if(u instanceof Zombie)
-				{
-					removeZombie(u.getRow(),u.getCol());
-					zomRemoveBin.add((Zombie) u);
-					LOG.debug("Lawnmower kills Zombie " + u.getRow() + " " + u.getCol());
-				}
-				else if(u instanceof Plant)
-				{
-					removePlant(u.getRow(),u.getCol());
-					LOG.debug("Lawnmower kills Plant " + u.getRow() + " " + u.getCol());
-				}
+				removeZombie(u.getRow(),u.getCol());
+				zomRemoveBin.add((Zombie) u);
+				LOG.debug("Lawnmower kills Zombie " + u.getRow() + " " + u.getCol());
+			}
+			else if(u instanceof Plant)
+			{
+				removePlant(u.getRow(),u.getCol());
+				LOG.debug("Lawnmower kills Plant " + u.getRow() + " " + u.getCol());
 			}
 		}
+		
 		return zomRemoveBin;
 	}
 	

--- a/src/engine/Board.java
+++ b/src/engine/Board.java
@@ -472,9 +472,11 @@ public class Board implements ZombieMoveListener, Serializable {
 		for (int col = 0; col < gameBoard[x].length; col++) {
 			if (!gameBoard[x][col].getZombies().isEmpty()) {
 				targets.addAll(gameBoard[x][col].getZombies());
+				LOG.debug("Adding Zombie to mower list: " + x + " " + col);
 			}
 			if (gameBoard[x][col].getPlant() != null) {
 				targets.add(gameBoard[x][col].getPlant());
+				LOG.debug("Adding Plant to mower list: " + x + " " + col);
 			}
 		}
 		return targets.isEmpty()? null : targets;
@@ -486,17 +488,32 @@ public class Board implements ZombieMoveListener, Serializable {
 	 */
 	public void useLawnMower(int row)
 	{
-		for(Unit u : getRowUnits(row))
+		if(!getRowUnits(row).isEmpty())
 		{
-			if(u instanceof Zombie)
+			for(Unit u : getRowUnits(row))
 			{
-				removeZombie(u.getRow(),u.getCol());
-			}
-			else if(u instanceof Plant)
-			{
-				removePlant(u.getRow(),u.getCol());
+				if(u instanceof Zombie)
+				{
+					removeZombie(u.getRow(),u.getCol());
+					LOG.debug("Lawnmower kills Zombie " + u.getRow() + " " + u.getCol());
+				}
+				else if(u instanceof Plant)
+				{
+					removePlant(u.getRow(),u.getCol());
+					LOG.debug("Lawnmower kills Plant " + u.getRow() + " " + u.getCol());
+				}
 			}
 		}
+	}
+	
+	/**
+	 * Checks if the mower is avaliable for the given row
+	 * @param row - the row to check if the lawn mower is avaliable
+	 * @return true if the lawn mower is avaliable for use, otherwise return false
+	 */
+	public boolean isMowerAvaliable(int row)
+	{
+		return mowersAvaliable.contains(row);
 	}
 	
 	@Override
@@ -542,11 +559,15 @@ public class Board implements ZombieMoveListener, Serializable {
 		if(currentZombieCol - modifier < 0)
 		{
 			zombie.setColumn(0);
+			// update the board with new position
+			gameBoard[zombie.getRow()][zombie.getCol()].addZombie(zombie);
 			
 			if(isMowerAvaliable(currentZombieRow) != true)
 				this.zombieReachedEnd = true;
 			else
 				useLawnMower(currentZombieRow);
+			
+			return true;
 		}
 		else
 		{
@@ -561,20 +582,6 @@ public class Board implements ZombieMoveListener, Serializable {
 		return true;
 	}
 	
-	/**
-	 * Checks if the mower is avaliable for the given row
-	 * @param row - the row to check if the lawn mower is avaliable
-	 * @return true if the lawn mower is avaliable for use, otherwise return false
-	 */
-	public boolean isMowerAvaliable(int row)
-	{
-		return mowersAvaliable.contains(row);
-	}
-	
-	public void useLawnMower()
-	{
-		
-	}
 	
 	/**
 	 * Gets the potential new position of the zombie when it is moving

--- a/src/engine/Board.java
+++ b/src/engine/Board.java
@@ -40,7 +40,7 @@ public class Board implements ZombieMoveListener, Serializable {
 	/* Checks if a Zombie has reached the end of the board
 	 * If a zombie has, then the game is over and the player loses
 	 * */
-	private boolean zombieReachedEnd;
+	//private boolean zombieReachedEnd;
 
 	/**
 	 * Track all plants currently in the game
@@ -59,6 +59,13 @@ public class Board implements ZombieMoveListener, Serializable {
 	private List<Integer> mowersAvaliable;
 	
 	/**
+	 * Tracks if a zombie has reached the end of the board.
+	 * Each index in the arraylist represents a row.
+	 * If the mower has been used, the index will contain a 1
+	 */
+	private int[] zombieReachedEnd;
+	
+	/**
 	 * Number of Sunflowers in game
 	 */
 	private int sfCounter;
@@ -74,13 +81,14 @@ public class Board implements ZombieMoveListener, Serializable {
 		this.row = row;
 		this.col = col;
 		
-		this.zombieReachedEnd = false;
+		//this.zombieReachedEnd = false;
 		
 		this.sfCounter = 0;
 		
 		this.zombiesInGame = new LinkedList<Zombie>();
 		this.plantsInGame = new LinkedList<Plant>();
 		this.mowersAvaliable = new ArrayList<Integer>();
+		this.zombieReachedEnd = new int[row];
 		
 		//initialize board and add all the avaliable lawn mowers to a list
 		gameBoard = new Grid[row][col];
@@ -164,9 +172,9 @@ public class Board implements ZombieMoveListener, Serializable {
 	 * 
 	 * @return true if a zombie has reached the end of a board, false otherwise
 	 */
-	public boolean hasReachedEnd() {
-		return this.zombieReachedEnd;
-	}
+	//public boolean hasReachedEnd() {
+	//	return this.zombieReachedEnd;
+	//}
 	
 	/**
 	 * Get the number of zombies currently in game.
@@ -472,11 +480,9 @@ public class Board implements ZombieMoveListener, Serializable {
 		for (int col = 0; col < gameBoard[x].length; col++) {
 			if (!gameBoard[x][col].getZombies().isEmpty()) {
 				targets.addAll(gameBoard[x][col].getZombies());
-				LOG.debug("Adding Zombie to mower list: " + x + " " + col);
 			}
 			if (gameBoard[x][col].getPlant() != null) {
 				targets.add(gameBoard[x][col].getPlant());
-				LOG.debug("Adding Plant to mower list: " + x + " " + col);
 			}
 		}
 		return targets.isEmpty()? null : targets;
@@ -511,6 +517,46 @@ public class Board implements ZombieMoveListener, Serializable {
 	}
 	
 	/**
+	 * Sets the mower used array for the specified index (1 = set).
+	 * The index represents the row that the lawn mower was used
+	 * @param row - the row that the lawn mower was used
+	 */
+	public void setZombieReachedEnd(int row)
+	{
+		zombieReachedEnd[row] = 1;
+	}
+	/**
+	 * Sets the mower used array for the specified index (0 = not set).
+	 * The index represents the row that the lawn mower was used
+	 * @param row - the row that the lawn mower was used
+	 */
+	public void resetZombieReachedEnd(int row)
+	{
+		zombieReachedEnd[row] = 0;
+	}
+	/**
+	 * Checks if the lawn mower for the specified row has been used
+	 * @param row - the row of the lawn mower
+	 * @return true if the lawn mower has been used, otherwise false
+	 */
+	public boolean hasReachedEnd(int row)
+	{
+		if(zombieReachedEnd[row] == 1)
+		{
+			return true;
+		}
+		return false;
+	}
+	/**
+	 * Removes a lawn mower from the mowersAvaliable list
+	 * @param row - the row in which the lawn mower is to be removed
+	 */
+	public void removeMower(int row)
+	{
+		mowersAvaliable.remove((Object) row);
+	}
+	
+	/**
 	 * Checks if the mower is avaliable for the given row
 	 * @param row - the row to check if the lawn mower is avaliable
 	 * @return true if the lawn mower is avaliable for use, otherwise return false
@@ -521,8 +567,9 @@ public class Board implements ZombieMoveListener, Serializable {
 		return mowersAvaliable.contains(row);
 	}
 	
+	
 	@Override
-	public boolean onZombieMove(Zombie zombie, Game game) {
+	public boolean onZombieMove(Zombie zombie) {
 		
 		int currentZombieRow = zombie.getRow();
 		int currentZombieCol = zombie.getCol();
@@ -566,18 +613,7 @@ public class Board implements ZombieMoveListener, Serializable {
 			zombie.setColumn(0);
 			// update the board with new position
 			gameBoard[zombie.getRow()][zombie.getCol()].addZombie(zombie);
-			
-			if(isMowerAvaliable(currentZombieRow) != true)
-				this.zombieReachedEnd = true;
-			else
-			{
-				game.setZomRemoveBin(useLawnMower(currentZombieRow));
-				for(GameListener g : game.getListeners())
-				{
-					g.updateMower(currentZombieRow);
-				}
-				mowersAvaliable.remove((Object) currentZombieRow);
-			}
+			setZombieReachedEnd(currentZombieRow);
 			
 			return true;
 		}

--- a/src/engine/Board.java
+++ b/src/engine/Board.java
@@ -517,7 +517,7 @@ public class Board implements ZombieMoveListener, Serializable {
 	}
 	
 	@Override
-	public boolean onZombieMove(Zombie zombie, int maxRow) {
+	public boolean onZombieMove(Zombie zombie, Game game) {
 		
 		int currentZombieRow = zombie.getRow();
 		int currentZombieCol = zombie.getCol();
@@ -550,7 +550,7 @@ public class Board implements ZombieMoveListener, Serializable {
 			
 			// can move zombie until it reaches end of grid or reaches a plant
 			if (!(currentZombieCol - i < 0)) {
-				if(getNewZomPosition(currentZombieRow, currentZombieCol, modifier, zombie, maxRow).isOccupied()){
+				if(getNewZomPosition(currentZombieRow, currentZombieCol, modifier, zombie, game.getLevelInfo().getRows()).isOccupied()){
 					break;
 				}
 			}
@@ -565,13 +565,19 @@ public class Board implements ZombieMoveListener, Serializable {
 			if(isMowerAvaliable(currentZombieRow) != true)
 				this.zombieReachedEnd = true;
 			else
+			{
 				useLawnMower(currentZombieRow);
+				for(GameListener g : game.getListeners())
+				{
+					g.updateMower(currentZombieRow);
+				}
+			}
 			
 			return true;
 		}
 		else
 		{
-			int[] coord = getNewZomPosition(currentZombieRow, currentZombieCol, modifier, zombie, maxRow).getCoordinates();
+			int[] coord = getNewZomPosition(currentZombieRow, currentZombieCol, modifier, zombie, game.getLevelInfo().getRows()).getCoordinates();
 			zombie.setRow(coord[0]);
 			zombie.setColumn(coord[1]);
 		}

--- a/src/engine/Board.java
+++ b/src/engine/Board.java
@@ -36,11 +36,6 @@ public class Board implements ZombieMoveListener, Serializable {
 
 	/* Number of columns in game board */
 	private int col;
-	
-	/* Checks if a Zombie has reached the end of the board
-	 * If a zombie has, then the game is over and the player loses
-	 * */
-	//private boolean zombieReachedEnd;
 
 	/**
 	 * Track all plants currently in the game
@@ -61,9 +56,9 @@ public class Board implements ZombieMoveListener, Serializable {
 	/**
 	 * Tracks if a zombie has reached the end of the board.
 	 * Each index in the arraylist represents a row.
-	 * If the mower has been used, the index will contain a 1
+	 * If the mower has been used, the index will be true
 	 */
-	private int[] zombieReachedEnd;
+	private boolean[] zombieReachedEnd;
 	
 	/**
 	 * Number of Sunflowers in game
@@ -81,14 +76,12 @@ public class Board implements ZombieMoveListener, Serializable {
 		this.row = row;
 		this.col = col;
 		
-		//this.zombieReachedEnd = false;
-		
 		this.sfCounter = 0;
 		
 		this.zombiesInGame = new LinkedList<Zombie>();
 		this.plantsInGame = new LinkedList<Plant>();
 		this.mowersAvaliable = new ArrayList<Integer>();
-		this.zombieReachedEnd = new int[row];
+		this.zombieReachedEnd = new boolean[row];
 		
 		//initialize board and add all the avaliable lawn mowers to a list
 		gameBoard = new Grid[row][col];
@@ -166,15 +159,6 @@ public class Board implements ZombieMoveListener, Serializable {
 	public Grid getGrid(int row, int col) {
 		return gameBoard[row][col];
 	}
-	
-	/**
-	 * Return whether a zombie has the end of a board.
-	 * 
-	 * @return true if a zombie has reached the end of a board, false otherwise
-	 */
-	//public boolean hasReachedEnd() {
-	//	return this.zombieReachedEnd;
-	//}
 	
 	/**
 	 * Get the number of zombies currently in game.
@@ -517,22 +501,22 @@ public class Board implements ZombieMoveListener, Serializable {
 	}
 	
 	/**
-	 * Sets the mower used array for the specified index (1 = set).
+	 * Sets the mower used array for the specified index (true = set).
 	 * The index represents the row that the lawn mower was used
 	 * @param row - the row that the lawn mower was used
 	 */
 	public void setZombieReachedEnd(int row)
 	{
-		zombieReachedEnd[row] = 1;
+		zombieReachedEnd[row] = true;
 	}
 	/**
-	 * Sets the mower used array for the specified index (0 = not set).
+	 * Sets the mower used array for the specified index (false = not set).
 	 * The index represents the row that the lawn mower was used
 	 * @param row - the row that the lawn mower was used
 	 */
 	public void resetZombieReachedEnd(int row)
 	{
-		zombieReachedEnd[row] = 0;
+		zombieReachedEnd[row] = false;
 	}
 	/**
 	 * Checks if the lawn mower for the specified row has been used
@@ -541,11 +525,7 @@ public class Board implements ZombieMoveListener, Serializable {
 	 */
 	public boolean hasReachedEnd(int row)
 	{
-		if(zombieReachedEnd[row] == 1)
-		{
-			return true;
-		}
-		return false;
+		return zombieReachedEnd[row];
 	}
 	/**
 	 * Removes a lawn mower from the mowersAvaliable list

--- a/src/engine/Board.java
+++ b/src/engine/Board.java
@@ -486,15 +486,19 @@ public class Board implements ZombieMoveListener, Serializable {
 	 * Deletes all the units within the specified row
 	 * @param row - the row that all the units will be deleted in
 	 */
-	public void useLawnMower(int row)
+	public List<Zombie> useLawnMower(int row)
 	{
-		if(!getRowUnits(row).isEmpty())
+		List<Unit> unitRemoveBin = getRowUnits(row);
+		List<Zombie> zomRemoveBin = new LinkedList<Zombie>();
+		
+		if(!unitRemoveBin.isEmpty())
 		{
-			for(Unit u : getRowUnits(row))
+			for(Unit u : unitRemoveBin)
 			{
 				if(u instanceof Zombie)
 				{
 					removeZombie(u.getRow(),u.getCol());
+					zomRemoveBin.add((Zombie) u);
 					LOG.debug("Lawnmower kills Zombie " + u.getRow() + " " + u.getCol());
 				}
 				else if(u instanceof Plant)
@@ -504,6 +508,7 @@ public class Board implements ZombieMoveListener, Serializable {
 				}
 			}
 		}
+		return zomRemoveBin;
 	}
 	
 	/**
@@ -566,7 +571,7 @@ public class Board implements ZombieMoveListener, Serializable {
 				this.zombieReachedEnd = true;
 			else
 			{
-				useLawnMower(currentZombieRow);
+				game.setZomRemoveBin(useLawnMower(currentZombieRow));
 				for(GameListener g : game.getListeners())
 				{
 					g.updateMower(currentZombieRow);

--- a/src/engine/Game.java
+++ b/src/engine/Game.java
@@ -99,7 +99,7 @@ public class Game implements Serializable {
 		while (iterator.hasNext()) {
 			Zombie nextZombie = iterator.next();
 			//if a zombie has failed to move, it means it is being blocked by a Plant
-			if (!nextZombie.move(levelInfo.getRows())) {
+			if (!nextZombie.move(this)) {
 				nextZombie.attack(board);
 			}
 
@@ -187,6 +187,16 @@ public class Game implements Serializable {
 			LOG.debug("Player was eaten by Zombies");
 			gamestate = GameState.LOST;
 		}
+	}
+	
+	/**
+	 * Get the game listeners (directs the view) 
+	 * 
+	 * @return
+	 */
+	public List<GameListener> getListeners()
+	{
+		return listeners;
 	}
 	 
 	 /**

--- a/src/engine/Game.java
+++ b/src/engine/Game.java
@@ -41,8 +41,10 @@ public class Game implements Serializable {
 	private HashMap<ZombieTypes, Integer> zombieQueue;
 	//The number of zombies (total) in the level
 	private int numZombies;
-	//the number of turns elapsed
+	//The number of turns elapsed
 	private int numTurns;
+	//The zombies that are to be removed
+	private List<Zombie> zomRemoveBin;
 
 	private GameState gamestate;
 
@@ -58,6 +60,7 @@ public class Game implements Serializable {
 		board = new Board(lvl.getRows(), lvl.getColumns());
 		levelInfo = lvl;
 		
+		zomRemoveBin = new LinkedList<Zombie>();
 		zombieQueue = (HashMap<ZombieTypes, Integer>) lvl.getZombies();
 		numZombies = zombieQueue.values().stream().mapToInt(Integer::intValue).sum();
 		LOG.debug("Level has " + numZombies + " zombies");
@@ -98,15 +101,18 @@ public class Game implements Serializable {
 		
 		while (iterator.hasNext()) {
 			Zombie nextZombie = iterator.next();
-			//if a zombie has failed to move, it means it is being blocked by a Plant
-			if (!nextZombie.move(this)) {
-				nextZombie.attack(board);
-			}
+			if(!getZomRemoveBin().contains(nextZombie))
+			{
+				//if a zombie has failed to move, it means it is being blocked by a Plant
+				if (!nextZombie.move(this)) {
+					nextZombie.attack(board);
+				}
 
-			if (board.hasReachedEnd()) {
-				// a zombie has reached the end of the board and player loses
-				endGame(false);
-				break;
+				if (board.hasReachedEnd()) {
+					// a zombie has reached the end of the board and player loses
+					endGame(false);
+					break;
+				}
 			}
 		}
 		
@@ -189,6 +195,15 @@ public class Game implements Serializable {
 		}
 	}
 	
+	
+	public void setZomRemoveBin(List zom)
+	{
+		zomRemoveBin.addAll(zom);
+	}
+	public List<Zombie> getZomRemoveBin()
+	{
+		return zomRemoveBin;
+	}
 	/**
 	 * Get the game listeners (directs the view) 
 	 * 

--- a/src/engine/Game.java
+++ b/src/engine/Game.java
@@ -104,12 +104,22 @@ public class Game implements Serializable {
 			if(!getZomRemoveBin().contains(nextZombie))
 			{
 				//if a zombie has failed to move, it means it is being blocked by a Plant
-				if (!nextZombie.move(this)) {
+				if (!nextZombie.move()) {
 					nextZombie.attack(board);
 				}
-
-				if (board.hasReachedEnd()) {
-					// a zombie has reached the end of the board and player loses
+				int row = nextZombie.getRow();
+				if(board.hasReachedEnd(row) && board.isMowerAvaliable(row))
+				{
+					setZomRemoveBin(board.useLawnMower(row));
+					for(GameListener g : listeners)
+					{
+						g.updateMower(row);
+					}
+					board.removeMower(row);
+					board.resetZombieReachedEnd(row);
+				}
+				else if(board.hasReachedEnd(row) && !board.isMowerAvaliable(row)) {
+					// a zombie has reached the end of the board and a lawnmower is not available. player loses
 					endGame(false);
 					break;
 				}
@@ -211,15 +221,6 @@ public class Game implements Serializable {
 	public List<Zombie> getZomRemoveBin()
 	{
 		return zomRemoveBin;
-	}
-	/**
-	 * Get the game listeners (directs the view) 
-	 * 
-	 * @return
-	 */
-	public List<GameListener> getListeners()
-	{
-		return listeners;
 	}
 	 
 	 /**

--- a/src/engine/Game.java
+++ b/src/engine/Game.java
@@ -101,9 +101,6 @@ public class Game implements Serializable {
 			//if a zombie has failed to move, it means it is being blocked by a Plant
 			if (!nextZombie.move(levelInfo.getRows())) {
 				nextZombie.attack(board);
-				if(nextZombie instanceof Exploding_Zombie){   				//if a exploding zombie attacks, it instantly dies
-					board.removeZombie(nextZombie.getRow(), nextZombie.getCol());
-				}
 			}
 
 			if (board.hasReachedEnd()) {

--- a/src/engine/Game.java
+++ b/src/engine/Game.java
@@ -195,11 +195,19 @@ public class Game implements Serializable {
 		}
 	}
 	
-	
+	/**
+	 * Sets the zombie remove bin.All the zombies within this list
+	 * will be removed from the board
+	 * @param zom - a list of zombies to be removed from the board
+	 */
 	public void setZomRemoveBin(List zom)
 	{
 		zomRemoveBin.addAll(zom);
 	}
+	/**
+	 * Retreives the zombie remove bin
+	 * @return - a list of zombies 
+	 */
 	public List<Zombie> getZomRemoveBin()
 	{
 		return zomRemoveBin;

--- a/src/engine/GameListener.java
+++ b/src/engine/GameListener.java
@@ -34,4 +34,11 @@ public interface GameListener {
 	 * @param message - the contents of the message
 	 */
 	public void updateMessage(String title, String message);
+	/**
+	 * Invoked whenever a the lawn mower is used. Returns true if the move was successful, false otherwise.
+	 * 
+	 * @param zombie
+	 * @return true if move was successful, false otherwise
+	 */
+	public void updateMower(int Row);
 }

--- a/src/engine/GameListener.java
+++ b/src/engine/GameListener.java
@@ -35,10 +35,8 @@ public interface GameListener {
 	 */
 	public void updateMessage(String title, String message);
 	/**
-	 * Invoked whenever a the lawn mower is used. Returns true if the move was successful, false otherwise.
-	 * 
-	 * @param zombie
-	 * @return true if move was successful, false otherwise
+	 * Tells the game listener that the lawn mower was used
+	 * @param Row - the row that the lawn mower was used
 	 */
 	public void updateMower(int Row);
 }

--- a/src/engine/Grid.java
+++ b/src/engine/Grid.java
@@ -7,6 +7,7 @@ import java.util.Queue;
 import assets.Plant;
 import assets.Zombie;
 import assets.ZombieTypes;
+import util.Logger;
  
 /**
  * Building block for a grid. Contains 1 Plant and N zombies.
@@ -16,6 +17,7 @@ import assets.ZombieTypes;
  */
 public class Grid implements Serializable {
 	private static final long serialVersionUID = 1L;
+	private static Logger LOG = new Logger("Grid");
 	private int row;
 	private int col;
 	
@@ -102,7 +104,6 @@ public class Grid implements Serializable {
 	 * @return true if zombie was added successfully, false otherwise
 	 */
 	public boolean addZombie(Zombie zombie) {
-		
 		if (zombies.add(zombie)) {
 		
 			zombieTypeCount.put(zombie.getZombieType(), zombieTypeCount.getOrDefault(zombie.getZombieType(), 0) + 1);
@@ -131,7 +132,6 @@ public class Grid implements Serializable {
 	 * @return the zombie that was killed, null if no zombies are present
 	 */
 	public Zombie removeZombie() {
-		
 		if (!zombies.isEmpty()) {
 			
 			Zombie zombieToRemove = zombies.peek();

--- a/src/engine/ZombieMoveListener.java
+++ b/src/engine/ZombieMoveListener.java
@@ -1,7 +1,5 @@
 package engine;
 
-import java.awt.List;
-
 import assets.Zombie;
 
 /**

--- a/src/engine/ZombieMoveListener.java
+++ b/src/engine/ZombieMoveListener.java
@@ -1,5 +1,7 @@
 package engine;
 
+import java.awt.List;
+
 import assets.Zombie;
 
 /**
@@ -17,5 +19,5 @@ public interface ZombieMoveListener {
 	 * @param zombie
 	 * @return true if move was successful, false otherwise
 	 */
-	public boolean onZombieMove(Zombie zombie, int maxRow);
+	public boolean onZombieMove(Zombie zombie, Game game);
 }

--- a/src/engine/ZombieMoveListener.java
+++ b/src/engine/ZombieMoveListener.java
@@ -19,5 +19,5 @@ public interface ZombieMoveListener {
 	 * @param zombie
 	 * @return true if move was successful, false otherwise
 	 */
-	public boolean onZombieMove(Zombie zombie, Game game);
+	public boolean onZombieMove(Zombie zombie);
 }

--- a/src/levels/LevelLoader.java
+++ b/src/levels/LevelLoader.java
@@ -40,9 +40,9 @@ public class LevelLoader {
 		sampleZombies.put(ZombieTypes.JUK_ZOMBIE, 1);
 		sampleZombies.put(ZombieTypes.AIR_ZOMBIE, 1);
 		sampleZombies.put(ZombieTypes.REG_ZOMBIE, 1);		
-		sampleZombies.put(ZombieTypes.RUSH_ZOMBIE, 1);		
-		sampleZombies.put(ZombieTypes.SPRINT_ZOMBIE, 1);
-		sampleZombies.put(ZombieTypes.EXP_ZOMBIE, 20);
+		sampleZombies.put(ZombieTypes.RUSH_ZOMBIE, 20);		
+		sampleZombies.put(ZombieTypes.SPRINT_ZOMBIE, 20);
+		sampleZombies.put(ZombieTypes.EXP_ZOMBIE, 1);
 		sampleZombies.put(ZombieTypes.YETI_ZOMBIE, 1);
 		sampleZombies.put(ZombieTypes.TANK_ZOMBIE, 1);
     

--- a/src/ui/GameUI.java
+++ b/src/ui/GameUI.java
@@ -257,6 +257,8 @@ public class GameUI extends JFrame implements GameListener
 
     	gui.add(cardHolder, BorderLayout.SOUTH);
     }
+    
+   
 
     /**
      * Once called, the specified unit card will be "highlighted".
@@ -480,5 +482,14 @@ public class GameUI extends JFrame implements GameListener
     @Override
     public void updateMessage(String title, String message) {
     	JOptionPane.showMessageDialog(null, message, title, JOptionPane.PLAIN_MESSAGE);
+    }
+    /**
+     * Removes the lawn mower icon in place of a grass tile 
+     * @param row - the row in which the lawn mower icon will be removed
+     */
+    @Override
+    public void updateMower(int row)
+    {
+    	mowers[row].setIcon(null);
     }
 }

--- a/src/unittests/BoardTest.java
+++ b/src/unittests/BoardTest.java
@@ -29,7 +29,7 @@ public class BoardTest {
 		Board b = new Board(4, 1);
 		assertEquals("Row should be 4 ", 4, b.getRow());
 		assertEquals("Column should be 1", 1, b.getColumn());	
-		assertFalse("Zombies have not reached end", b.hasReachedEnd());
+		assertFalse("Zombies have not reached end", b.hasReachedEnd(0));
 		assertEquals("Number of sunflower", 0, b.getNumberOfSF());
 	}
 	
@@ -140,12 +140,12 @@ public class BoardTest {
 		Peashooter p = new Peashooter();
 		b.placePlant(p, 0, 2);
 		b.placeZombie(z1, z1.getRow(), z1.getCol());
-		assertFalse("False",z1.move(game));
+		assertFalse("False",z1.move());
 		b.displayBoard();
 		
 		b.placeZombie(z2, z2.getRow(), z2.getCol());
 		b.displayBoard();
-		assertTrue("True", z2.move(game));//error
+		assertTrue("True", z2.move());//error
 	}
 	
 	

--- a/src/unittests/BoardTest.java
+++ b/src/unittests/BoardTest.java
@@ -65,7 +65,7 @@ public class BoardTest {
 	/**
 	 * tests all getPlant() Methods
 	 */
-	//@Test
+	@Test
 	public void testGetPlantMethods() {
 		Board b = new Board(1,4);
 		Flower f = new Flower();
@@ -214,18 +214,10 @@ public class BoardTest {
 		Regular_Zombie z2 = new Regular_Zombie();
 		Regular_Zombie z3 = new Regular_Zombie();
 		Regular_Zombie z4 = new Regular_Zombie();
-		z1.setRow(0);
-		z1.setColumn(2);
-		b.placeZombie(z1, z1.getRow(), z1.getCol());
-		z2.setRow(0);
-		z2.setColumn(3);
-		b.placeZombie(z2, z2.getRow(), z2.getCol());
-		z3.setRow(0);
-		z3.setColumn(6);
-		b.placeZombie(z3, z3.getRow(), z3.getCol());
-		z4.setRow(0);
-		z4.setColumn(7);
-		b.placeZombie(z4, z4.getRow(), z4.getCol());
+		b.placeZombie(z1, 0, 2);
+		b.placeZombie(z2, 0, 3);
+		b.placeZombie(z3, 0, 6);
+		b.placeZombie(z4, 0, 7);
 		
 		Peashooter p = new Peashooter();
 		Peashooter p2 = new Peashooter();
@@ -249,44 +241,33 @@ public class BoardTest {
 	{
 		Board b = new Board(5,20);
 		Regular_Zombie z1 = new Regular_Zombie();
-		z1.setRow(0);
-		z1.setColumn(7);
-		b.placeZombie(z1, z1.getRow(), z1.getCol());
+		b.placeZombie(z1, 0, 7);
 		
-		assertEquals(0, b.getNewZomPosition(z1.getRow(),z1.getCol(),1,z1, 5).getRow()); //testing for regular zombie
-		assertEquals(6, b.getNewZomPosition(z1.getRow(),z1.getCol(),1,z1, 5).getCol()); 
+		assertEquals(0, b.getNewZomPosition(0, 7, 2, z1, 5).getRow()); //testing for regular zombie
+		assertEquals(5, b.getNewZomPosition(0, 7, 2, z1, 5).getCol()); 
 		
 		Juking_Zombie z2 = new Juking_Zombie();
-		z2.setRow(0);
-		z2.setColumn(7);
-		b.placeZombie(z2, z2.getRow(), z2.getCol());
+		b.placeZombie(z2, 0, 7);
 		assertEquals(1, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow()); //testing for when juking zombie starting at row 0 
 		assertEquals(6, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
 		
-		z2.setRow(1);
-		z2.setColumn(6);
-		b.placeZombie(z2, z2.getRow(), z2.getCol());
+		b.placeZombie(z2, 1, 6);
 		assertEquals(2, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow()); //testing for when juking zombie starts off not at the edges of the board
 		assertEquals(5, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
 		
-		z2.setRow(4);
-		z2.setColumn(19);
+		b.placeZombie(z2, 4, 19);
 		//Should be 3, 18
 		assertEquals(3, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow()); //testing for when juking zombie is at the bottom of the board
 		assertEquals(18, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
-		z2.setRow(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow());   
-		z2.setColumn(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());  
+		b.placeZombie(z2, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow(), b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol()); 
 		//Should be 2, 17
 		assertEquals(2, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow()); //testing for when juking zombie is not at the edges of the board 
 		assertEquals(17, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
-		z2.setRow(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow());
-		z2.setColumn(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
+		b.placeZombie(z2, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow(), b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol()); 
 		//Should be 1, 16
-		z2.setRow(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow());  
-		z2.setColumn(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
+		b.placeZombie(z2, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow(), b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol()); 
 		//Should be 0, 15
-		z2.setRow(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow());
-		z2.setColumn(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
+		b.placeZombie(z2, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow(), b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol()); 
 		//Should be 1,14
 		assertEquals(1, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow()); //testing for when juking zombie hits the other side of the board
 		assertEquals(14, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());

--- a/src/unittests/BoardTest.java
+++ b/src/unittests/BoardTest.java
@@ -8,6 +8,10 @@ import levels.LevelLoader;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -20,7 +24,7 @@ public class BoardTest {
 	/**
 	 * tests Board constructor
 	 */
-	@Test
+	//@Test
 	public void testBoardConstructor() {
 		Board b = new Board(4, 1);
 		assertEquals("Row should be 4 ", 4, b.getRow());
@@ -32,7 +36,7 @@ public class BoardTest {
 	/**
 	 * tests getBoard() method
 	 */
-	@Test
+	//@Test
 	public void testGetBoard() {
 		Board b = new Board(4, 1);
 		int expected = new Grid[4][1].length;
@@ -43,7 +47,7 @@ public class BoardTest {
 	/**
 	 * tests placePlant() method
 	 */
-	@Test
+	//@Test
 	public void testPlacePlant() {
 		Board b = new Board(4,1);
 		assertTrue("Plant Placed.", b.placePlant(new Flower(), 0, 0));
@@ -52,7 +56,7 @@ public class BoardTest {
 	/**
 	 * tests placeZombie() method
 	 */
-	@Test
+	//@Test
 	public void testPlaceZombie() {
 		Board b = new Board(1,4);
 		assertTrue("Zombie Placed.", b.placeZombie(new Regular_Zombie(), 0, 3));
@@ -61,7 +65,7 @@ public class BoardTest {
 	/**
 	 * tests all getPlant() Methods
 	 */
-	@Test
+	//@Test
 	public void testGetPlantMethods() {
 		Board b = new Board(1,4);
 		Flower f = new Flower();
@@ -78,7 +82,7 @@ public class BoardTest {
 	/**
 	 * tests all getZombie() methods
 	 */
-	@Test
+	//@Test
 	public void testGetZombieMethods() {
 		Board b = new Board(1,4);
 		Zombie z = new Regular_Zombie();
@@ -91,7 +95,7 @@ public class BoardTest {
 	/**
 	 * tests removePlant() method
 	 */
-	@Test
+	//@Test
 	public void testRemovePlant() {
 		Board b = new Board(1,4);
 		Peashooter p = new Peashooter();
@@ -106,7 +110,7 @@ public class BoardTest {
 	/**
 	 * tests removeZombie() method
 	 */
-	@Test
+	//@Test
 	public void testRemoveZombie() {
 		Board b = new Board(4,1);
 		Zombie z = new Regular_Zombie();
@@ -118,7 +122,7 @@ public class BoardTest {
 	/**
 	 * tests testOnZombieMove() method
 	 */
-	@Test
+	//@Test
 	public void testOnZombieMove() {
 		LevelInfo lvl = LevelLoader.getLevel(1);
 		Game game = new Game(lvl);
@@ -142,5 +146,149 @@ public class BoardTest {
 		b.placeZombie(z2, z2.getRow(), z2.getCol());
 		b.displayBoard();
 		assertTrue("True", z2.move(game));//error
+	}
+	
+	
+	/**
+	 * tests testOnZombieMove() method
+	 */
+	@Test
+	public void testgetRowUnits() {
+		Board b = new Board(8,8);
+		Regular_Zombie z1 = new Regular_Zombie();
+		Regular_Zombie z2 = new Regular_Zombie();
+		Regular_Zombie z3 = new Regular_Zombie();
+		Regular_Zombie z4 = new Regular_Zombie();
+		z1.setRow(0);
+		z1.setColumn(2);
+		b.placeZombie(z1, z1.getRow(), z1.getCol());
+		z2.setRow(0);
+		z2.setColumn(3);
+		b.placeZombie(z2, z2.getRow(), z2.getCol());
+		z3.setRow(0);
+		z3.setColumn(7);
+		z1.setListener(b);
+		z2.setListener(b);
+		z4.setRow(0);
+		z4.setColumn(6);
+		
+		Peashooter p = new Peashooter();
+		Peashooter p2 = new Peashooter();
+		Peashooter p3 = new Peashooter();
+		Peashooter p4 = new Peashooter();
+		b.placePlant(p, 0, 2);
+		b.placePlant(p2, 0, 5);
+		b.placePlant(p3, 0, 6);
+		b.placePlant(p4, 0, 7);
+		
+		ArrayList<Unit> unitList = new ArrayList<Unit>();
+		unitList.add(z1);
+		unitList.add(p);
+		unitList.add(z2);
+		unitList.add(p2);
+		unitList.add(p3);
+		
+		
+		for(int i = 0; i < unitList.size();i++)
+		{
+			assertEquals(unitList.get(i),b.getRowUnits(0).get(i));
+		}
+		unitList.add(z3);
+		b.placeZombie(z3, z3.getRow(), z3.getCol());
+		unitList.add(p4);
+		for(int i = 0; i < unitList.size();i++)
+		{
+			assertEquals(unitList.get(i),b.getRowUnits(0).get(i));
+		}
+	}
+	
+	/**
+	 * Tests the UseLawnMower method. 
+	 * Assumes the getRowUnits is working as intended
+	 */
+	@Test
+	public void testUseLawnMower()
+	{
+		Board b = new Board(8,8);
+		Regular_Zombie z1 = new Regular_Zombie();
+		Regular_Zombie z2 = new Regular_Zombie();
+		Regular_Zombie z3 = new Regular_Zombie();
+		Regular_Zombie z4 = new Regular_Zombie();
+		z1.setRow(0);
+		z1.setColumn(2);
+		b.placeZombie(z1, z1.getRow(), z1.getCol());
+		z2.setRow(0);
+		z2.setColumn(3);
+		b.placeZombie(z2, z2.getRow(), z2.getCol());
+		z3.setRow(0);
+		z3.setColumn(6);
+		b.placeZombie(z3, z3.getRow(), z3.getCol());
+		z4.setRow(0);
+		z4.setColumn(7);
+		b.placeZombie(z4, z4.getRow(), z4.getCol());
+		
+		Peashooter p = new Peashooter();
+		Peashooter p2 = new Peashooter();
+		b.placePlant(p, 0, 2);
+		b.placePlant(p2, 0, 5);
+		
+		ArrayList<Zombie> zomList = new ArrayList<Zombie>();
+		zomList.add(z1);
+		zomList.add(z2);
+		zomList.add(z3);
+		zomList.add(z4);
+		
+		assertEquals(zomList, b.useLawnMower(0));
+	}
+	
+	/**
+	 * Tests the getNewZomPosition method
+	 */
+	@Test
+	public void testGetNewZomPostion()
+	{
+		Board b = new Board(5,20);
+		Regular_Zombie z1 = new Regular_Zombie();
+		z1.setRow(0);
+		z1.setColumn(7);
+		b.placeZombie(z1, z1.getRow(), z1.getCol());
+		
+		assertEquals(0, b.getNewZomPosition(z1.getRow(),z1.getCol(),1,z1, 5).getRow()); //testing for regular zombie
+		assertEquals(6, b.getNewZomPosition(z1.getRow(),z1.getCol(),1,z1, 5).getCol()); 
+		
+		Juking_Zombie z2 = new Juking_Zombie();
+		z2.setRow(0);
+		z2.setColumn(7);
+		b.placeZombie(z2, z2.getRow(), z2.getCol());
+		assertEquals(1, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow()); //testing for when juking zombie starting at row 0 
+		assertEquals(6, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
+		
+		z2.setRow(1);
+		z2.setColumn(6);
+		b.placeZombie(z2, z2.getRow(), z2.getCol());
+		assertEquals(2, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow()); //testing for when juking zombie starts off not at the edges of the board
+		assertEquals(5, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
+		
+		z2.setRow(4);
+		z2.setColumn(19);
+		//Should be 3, 18
+		assertEquals(3, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow()); //testing for when juking zombie is at the bottom of the board
+		assertEquals(18, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
+		z2.setRow(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow());   
+		z2.setColumn(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());  
+		//Should be 2, 17
+		assertEquals(2, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow()); //testing for when juking zombie is not at the edges of the board 
+		assertEquals(17, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
+		z2.setRow(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow());
+		z2.setColumn(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
+		//Should be 1, 16
+		z2.setRow(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow());  
+		z2.setColumn(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
+		//Should be 0, 15
+		z2.setRow(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow());
+		z2.setColumn(b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
+		//Should be 1,14
+		assertEquals(1, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getRow()); //testing for when juking zombie hits the other side of the board
+		assertEquals(14, b.getNewZomPosition(z2.getRow(),z2.getCol(),1,z2, 5).getCol());
 	}
 }

--- a/src/unittests/BoardTest.java
+++ b/src/unittests/BoardTest.java
@@ -121,6 +121,7 @@ public class BoardTest {
 	@Test
 	public void testOnZombieMove() {
 		LevelInfo lvl = LevelLoader.getLevel(1);
+		Game game = new Game(lvl);
 		Board b = new Board(2,4);
 		Regular_Zombie z1 = new Regular_Zombie();
 		Regular_Zombie z2 = new Regular_Zombie();
@@ -135,11 +136,11 @@ public class BoardTest {
 		Peashooter p = new Peashooter();
 		b.placePlant(p, 0, 2);
 		b.placeZombie(z1, z1.getRow(), z1.getCol());
-		assertFalse("False",z1.move(lvl.getRows()));
+		assertFalse("False",z1.move(game));
 		b.displayBoard();
 		
 		b.placeZombie(z2, z2.getRow(), z2.getCol());
 		b.displayBoard();
-		assertTrue("True", z2.move(lvl.getRows()));//error
+		assertTrue("True", z2.move(game));//error
 	}
 }

--- a/src/unittests/BoardTest.java
+++ b/src/unittests/BoardTest.java
@@ -24,7 +24,7 @@ public class BoardTest {
 	/**
 	 * tests Board constructor
 	 */
-	//@Test
+	@Test
 	public void testBoardConstructor() {
 		Board b = new Board(4, 1);
 		assertEquals("Row should be 4 ", 4, b.getRow());
@@ -36,7 +36,7 @@ public class BoardTest {
 	/**
 	 * tests getBoard() method
 	 */
-	//@Test
+	@Test
 	public void testGetBoard() {
 		Board b = new Board(4, 1);
 		int expected = new Grid[4][1].length;
@@ -47,7 +47,7 @@ public class BoardTest {
 	/**
 	 * tests placePlant() method
 	 */
-	//@Test
+	@Test
 	public void testPlacePlant() {
 		Board b = new Board(4,1);
 		assertTrue("Plant Placed.", b.placePlant(new Flower(), 0, 0));
@@ -56,7 +56,7 @@ public class BoardTest {
 	/**
 	 * tests placeZombie() method
 	 */
-	//@Test
+	@Test
 	public void testPlaceZombie() {
 		Board b = new Board(1,4);
 		assertTrue("Zombie Placed.", b.placeZombie(new Regular_Zombie(), 0, 3));
@@ -82,7 +82,7 @@ public class BoardTest {
 	/**
 	 * tests all getZombie() methods
 	 */
-	//@Test
+	@Test
 	public void testGetZombieMethods() {
 		Board b = new Board(1,4);
 		Zombie z = new Regular_Zombie();
@@ -95,7 +95,7 @@ public class BoardTest {
 	/**
 	 * tests removePlant() method
 	 */
-	//@Test
+	@Test
 	public void testRemovePlant() {
 		Board b = new Board(1,4);
 		Peashooter p = new Peashooter();
@@ -110,7 +110,7 @@ public class BoardTest {
 	/**
 	 * tests removeZombie() method
 	 */
-	//@Test
+	@Test
 	public void testRemoveZombie() {
 		Board b = new Board(4,1);
 		Zombie z = new Regular_Zombie();
@@ -122,7 +122,7 @@ public class BoardTest {
 	/**
 	 * tests testOnZombieMove() method
 	 */
-	//@Test
+	@Test
 	public void testOnZombieMove() {
 		LevelInfo lvl = LevelLoader.getLevel(1);
 		Game game = new Game(lvl);

--- a/src/unittests/CombatTest.java
+++ b/src/unittests/CombatTest.java
@@ -43,6 +43,7 @@ public class CombatTest {
 	@Test
 	public void testZombieAttack() {
 		LevelInfo lvl = LevelLoader.getLevel(1);
+		Game game = new Game(lvl);
 		Board b = new Board(1,8);
 		Peashooter p = new Peashooter();
 		Regular_Zombie z = new Regular_Zombie();
@@ -51,7 +52,7 @@ public class CombatTest {
 		
 		int turnsRequiredToKillZombies = p.getHP()/z.getPower();
 		
-		if(b.onZombieMove(z,lvl.getRows())==false){ //if zombie reached the plant unit
+		if(b.onZombieMove(z,game)==false){ //if zombie reached the plant unit
 			for(int i = 0; i<turnsRequiredToKillZombies; i++) {
 				z.attack(b); //kill plant until dead
 			}

--- a/src/unittests/CombatTest.java
+++ b/src/unittests/CombatTest.java
@@ -52,7 +52,7 @@ public class CombatTest {
 		
 		int turnsRequiredToKillZombies = p.getHP()/z.getPower();
 		
-		if(b.onZombieMove(z,game)==false){ //if zombie reached the plant unit
+		if(b.onZombieMove(z)==false){ //if zombie reached the plant unit
 			for(int i = 0; i<turnsRequiredToKillZombies; i++) {
 				z.attack(b); //kill plant until dead
 			}


### PR DESCRIPTION
Fixed some of Derek's concerns. I still send Game over to board via the move method for the following reason. 

The game instance is passed for two reasons, one to process the new zombie location after a move (via getNewZomPosition) and two, to update the lawn mower in the view (via GameListener). The problem is that to update the lawn mower in view, the row of the lawn mower is needed. I can't return it back to Game because the move method already returns a boolean value, thus it seems I must send the Game instance to the board.